### PR TITLE
Add description to Readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This is the Next JS re-write of the Buoy Viewer (originally written in Vue). Sty
 Install the dependencies through `npm` and start the development server.
 
 ```bash
-npm run install
+npm install
 npm run dev
 ```
 


### PR DESCRIPTION
Replaces the default `create-next-app` readme with useful information.