### PR TITLE
fix: do not export pagewrappers

### DIFF
--- a/src/app/datasets/massachusetts-buoys/page.tsx
+++ b/src/app/datasets/massachusetts-buoys/page.tsx
@@ -36,7 +36,7 @@ export default async function MassachusettsBuoyData({ searchParams }: PageProps)
   );
 }
 
-export async function PageWrapper({
+async function PageWrapper({
   params,
   errorLinks,
 }: {

--- a/src/app/datasets/rhode-island-buoys/page.tsx
+++ b/src/app/datasets/rhode-island-buoys/page.tsx
@@ -35,7 +35,7 @@ export default async function MassachusettsBuoyData({ searchParams }: PageProps)
   );
 }
 
-export async function PageWrapper({
+async function PageWrapper({
   params,
   errorLinks,
 }: {


### PR DESCRIPTION
Build error seemed to be from the PageWrapper export in the buoy pages. This seems to fix it locally!