### PR TITLE
Filter out null stream gage values

### DIFF
--- a/src/utils/data/stream-gage/downsample.ts
+++ b/src/utils/data/stream-gage/downsample.ts
@@ -23,7 +23,8 @@ export function downsampleStreamGageData(data: StreamGageData[], interval: Inter
       values: Object.entries(
         // Group data based on proximity to each time interval entry
         groupBy(
-          bouy.values,
+          // USGS States that values of -9999 indicate that no data was reported by the Stream Gage at this time point.
+          bouy.values.filter(({ value }) => value > -9990),
           (dataPoint: TimeSeriesDataPoint) => closestIndexTo(dataPoint.dateTime, binIntervals) || -1
         )
 


### PR DESCRIPTION
Fixes the null data being reported from the USGS page!

<img width="3456" height="1514" alt="image" src="https://github.com/user-attachments/assets/b93a86f5-6bbc-4527-aa95-09fe1a844c1e" />