### PR TITLE
fix: svg viewbox and font size to work for mobile

### DIFF
--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -34,7 +34,7 @@ function sizeTailwindClass(size: Size) {
   if (size === 'md') return 'text-2xl';
   if (size === 'lg') return 'text-3xl';
   if (size === 'xl') return 'text-4xl';
-  // size === "hero"
+  if (size === 'hero') return 'text-5xl';
   return 'text-7xl';
 }
 

--- a/src/components/Image/NarBay.tsx
+++ b/src/components/Image/NarBay.tsx
@@ -10,7 +10,7 @@ export default function NarBay({ className = '' }: { className?: string }) {
       y="0px"
       // Originally viewBox="0 0 1396.4 762.4"
       // This was constrained to make a better Hero image.
-      viewBox="0 200 1396.4 552.4"
+      viewBox="0 200 900.4 552.4"
       xmlSpace="preserve"
       className={className}
     >


### PR DESCRIPTION
Fixes the hero svg viewbox and hero font to work on mobile

<img width="994" height="659" alt="image" src="https://github.com/user-attachments/assets/5c126545-8c01-4582-ae0b-3612b6ab73b6" />
<img width="307" height="576" alt="image" src="https://github.com/user-attachments/assets/29c9f4b2-6f6a-4f43-9a7f-7b2223c62f5a" />
