### PR TITLE
Fix: Map Tile Flash Bug

### DIFF
--- a/src/components/visualizations/Maps/OsomExplorerMap.tsx
+++ b/src/components/visualizations/Maps/OsomExplorerMap.tsx
@@ -129,9 +129,7 @@ export function OsomExporerMap({
         <div className="flex flex-col gap-2 absolute top-[3%] left-3 md:top-[8%] md:left-8 bg-white/90 dark:bg-slate-800/90 p-4 rounded-md overflow-auto">
           <Header size="sm" tag="h3">
             {VARIABLE_OPTS.find(({ value }) => variable === value)?.label} on{' '}
-            <span className="font-mono">
-              {format(convertOsomIndexToDate(timepoints[rasterIndex]), 'MM/dd/yyyy')}
-            </span>
+            {format(convertOsomIndexToDate(timepoints[rasterIndex]), 'MM/dd/yyyy')}
           </Header>
           <div className="flex flex-row gap-2 items-center">
             <span>

--- a/src/components/visualizations/Maps/OsomExplorerMap.tsx
+++ b/src/components/visualizations/Maps/OsomExplorerMap.tsx
@@ -70,39 +70,50 @@ export function OsomExporerMap({
     window.history.replaceState({}, '', url);
   }, [dataset, variable, rasterIndex]);
 
-  const rasterUrl = React.useMemo(
-    () => getRasterUrl(dataset, rasterIndex, variable),
-    [dataset, rasterIndex, variable]
-  );
+  React.useEffect(() => {
+    if (loaded) {
+      timepoints
+        .map((_, index) => ({ index, url: getRasterUrl(dataset, index, variable) }))
+        .forEach(({ index, url }) => {
+          map.current.addSource(`osom-data-${index}`, {
+            type: 'raster',
+            tiles: [url],
+            attribution: 'Ocean State Ocean Model',
+          });
+          map.current.addLayer({
+            id: `osom-raster-${index}`,
+            type: 'raster',
+            source: `osom-data-${index}`,
+            layout: {
+              visibility: index === rasterIndex ? "visible" : "none",
+            }
+          });
+        });
 
-  React.useEffect(() => console.log(rasterUrl), [rasterUrl]);
+      return () => {
+        timepoints.forEach((_, index) => {
+          map.current.removeLayer(`osom-raster-${index}`);
+          map.current.removeSource(`osom-data-${index}`);
+        });
+      };
+    }
+  }, [loaded, timepoints, dataset, variable]);
 
   React.useEffect(() => {
     if (loaded) {
-      map.current.addSource('osom-data', {
-        type: 'raster',
-        tiles: [rasterUrl],
-        attribution: 'Ocean State Ocean Model',
-      });
-
-      map.current.addLayer({
-        id: 'osom-raster',
-        type: 'raster',
-        source: 'osom-data',
-      });
-
+      timepoints.forEach(index => map.current.setLayoutProperty(`osom-raster-${index}`, "visibility", "none"));
+      map.current.setLayoutProperty(`osom-raster-${rasterIndex}`, "visibility", "visible");
       return () => {
-        map.current.removeLayer('osom-raster');
-        map.current.removeSource('osom-data');
-      };
+        map.current.setLayoutProperty(`osom-raster-${rasterIndex}`, "visibility", "none");
+      }
     }
-  }, [loaded, rasterUrl]);
+  }, [timepoints, rasterIndex]);
 
   const incrementIndex = React.useCallback(() => {
     setRasterIndex((current) => (current + 1 >= timepoints.length ? 0 : current + 1));
   }, [setRasterIndex, timepoints]);
 
-  useInterval(incrementIndex, autoplay ? 2000 : undefined);
+  useInterval(incrementIndex, autoplay ? 200 : undefined);
 
   return (
     <>
@@ -111,7 +122,7 @@ export function OsomExporerMap({
         <div className="flex flex-col gap-2 absolute top-[3%] left-3 md:top-[8%] md:left-8 bg-white/90 dark:bg-slate-800/90 p-4 rounded-md overflow-auto">
           <Header size="sm" tag="h3">
             {VARIABLE_OPTS.find(({ value }) => variable === value)?.label} on{' '}
-            {format(convertOsomIndexToDate(timepoints[rasterIndex]), 'MM/dd/yyyy')}
+            <span className="font-mono">{format(convertOsomIndexToDate(timepoints[rasterIndex]), 'MM/dd/yyyy')}</span>
           </Header>
           <div className="flex flex-row gap-2 items-center">
             <span>

--- a/src/components/visualizations/Maps/OsomExplorerMap.tsx
+++ b/src/components/visualizations/Maps/OsomExplorerMap.tsx
@@ -40,6 +40,8 @@ const VARIABLE_BOUNDS: Record<Variable, { min: number; max: number }> = {
 const HALINE_GRADIENT = 'linear-gradient(0.25turn, #2a186e, #125e8e, #3c9486, #80cd64, #fbee97)';
 const THERMAL_GRADIENT = 'linear-gradient(0.25turn, #032333, #634197, #b5607f, #fa973f, #e7fa5a)';
 
+const AUTOPLAY_SPEED_MS = 2000;
+
 const OSOM_BOUNDS: LngLatBoundsLike = [
   [-72.7, 41.9],
   [-69.96, 40.5],
@@ -56,11 +58,6 @@ export function OsomExporerMap({
   const [rasterIndex, setRasterIndex] = React.useState(initialRasterIndex);
   const [autoplay, setAutoplay] = React.useState(false);
 
-  const timepoints = React.useMemo(
-    () => (dataset === 'annual-jan' ? TIMEPOITS_ANNUAL_JAN : TIMEPOITS_ANNUAL_JUL),
-    [dataset]
-  );
-
   React.useEffect(() => {
     // Sync visualization state with URL params
     const url = new URL(window.location.href);
@@ -69,6 +66,19 @@ export function OsomExporerMap({
     url.searchParams.set('index', rasterIndex.toString());
     window.history.replaceState({}, '', url);
   }, [dataset, variable, rasterIndex]);
+
+  const timepoints = React.useMemo(
+    () => (dataset === 'annual-jan' ? TIMEPOITS_ANNUAL_JAN : TIMEPOITS_ANNUAL_JUL),
+    [dataset]
+  );
+
+  const incrementIndex = React.useCallback(() => {
+    setRasterIndex((current) => (current + 1 >= timepoints.length ? 0 : current + 1));
+  }, [setRasterIndex, timepoints]);
+
+  useInterval(incrementIndex, autoplay ? AUTOPLAY_SPEED_MS : undefined);
+
+  // Initialize the map with sources for all timepoints.
 
   React.useEffect(() => {
     if (loaded) {
@@ -85,6 +95,8 @@ export function OsomExporerMap({
             type: 'raster',
             source: `osom-data-${index}`,
             layout: {
+              // Initially, set the selected layer to visible, with all others
+              // being invisible.
               visibility: index === rasterIndex ? 'visible' : 'none',
             },
           });
@@ -99,23 +111,16 @@ export function OsomExporerMap({
     }
   }, [loaded, timepoints, dataset, variable]);
 
+  // Hide all non-visible layers, and make the selected layer visible.
+
   React.useEffect(() => {
     if (loaded) {
       timepoints.forEach((index) =>
         map.current.setLayoutProperty(`osom-raster-${index}`, 'visibility', 'none')
       );
       map.current.setLayoutProperty(`osom-raster-${rasterIndex}`, 'visibility', 'visible');
-      return () => {
-        map.current.setLayoutProperty(`osom-raster-${rasterIndex}`, 'visibility', 'none');
-      };
     }
   }, [timepoints, rasterIndex]);
-
-  const incrementIndex = React.useCallback(() => {
-    setRasterIndex((current) => (current + 1 >= timepoints.length ? 0 : current + 1));
-  }, [setRasterIndex, timepoints]);
-
-  useInterval(incrementIndex, autoplay ? 200 : undefined);
 
   return (
     <>

--- a/src/components/visualizations/Maps/OsomExplorerMap.tsx
+++ b/src/components/visualizations/Maps/OsomExplorerMap.tsx
@@ -85,8 +85,8 @@ export function OsomExporerMap({
             type: 'raster',
             source: `osom-data-${index}`,
             layout: {
-              visibility: index === rasterIndex ? "visible" : "none",
-            }
+              visibility: index === rasterIndex ? 'visible' : 'none',
+            },
           });
         });
 
@@ -101,11 +101,13 @@ export function OsomExporerMap({
 
   React.useEffect(() => {
     if (loaded) {
-      timepoints.forEach(index => map.current.setLayoutProperty(`osom-raster-${index}`, "visibility", "none"));
-      map.current.setLayoutProperty(`osom-raster-${rasterIndex}`, "visibility", "visible");
+      timepoints.forEach((index) =>
+        map.current.setLayoutProperty(`osom-raster-${index}`, 'visibility', 'none')
+      );
+      map.current.setLayoutProperty(`osom-raster-${rasterIndex}`, 'visibility', 'visible');
       return () => {
-        map.current.setLayoutProperty(`osom-raster-${rasterIndex}`, "visibility", "none");
-      }
+        map.current.setLayoutProperty(`osom-raster-${rasterIndex}`, 'visibility', 'none');
+      };
     }
   }, [timepoints, rasterIndex]);
 
@@ -122,7 +124,9 @@ export function OsomExporerMap({
         <div className="flex flex-col gap-2 absolute top-[3%] left-3 md:top-[8%] md:left-8 bg-white/90 dark:bg-slate-800/90 p-4 rounded-md overflow-auto">
           <Header size="sm" tag="h3">
             {VARIABLE_OPTS.find(({ value }) => variable === value)?.label} on{' '}
-            <span className="font-mono">{format(convertOsomIndexToDate(timepoints[rasterIndex]), 'MM/dd/yyyy')}</span>
+            <span className="font-mono">
+              {format(convertOsomIndexToDate(timepoints[rasterIndex]), 'MM/dd/yyyy')}
+            </span>
           </Header>
           <div className="flex flex-row gap-2 items-center">
             <span>


### PR DESCRIPTION
Thanks @broarr for helping me figure this out!

There was an issue with the map tiles that would cause the tiles to flicker slightly when different timepoints were selected. This has been updated to cache the timepoint images and then only adjust layer visibility instead of refetching the later every update.