### PR TITLE
feat: add links to Globus endpoints for OSOM annual files and ROMS fo…

### DIFF
--- a/src/app/datasets/osom/explorer/page.tsx
+++ b/src/app/datasets/osom/explorer/page.tsx
@@ -18,9 +18,9 @@ export default async function OsomExplorer(props: PageProps) {
         see how the temperature, water salinity, and kinetic energy change over space and time.
       </p>
       <p style={{ marginTop: '1rem' }}>
-        NetCDF files for the entire OSOM dataset are available for download from{' '}
+        NetCDF files for the entire OSOM dataset are available for download from a{' '}
         <ExternalLink href="https://app.globus.org/file-manager?origin_id=660ecb5a-b446-4a71-9518-a98da0c12252&origin_path=%2F">
-        a Globus Collection.
+          Globus Collection.
         </ExternalLink>
       </p>
       <OsomExporerMap dataset={dataset} variable={variable} rasterIndex={rasterIndex} />

--- a/src/app/datasets/osom/explorer/page.tsx
+++ b/src/app/datasets/osom/explorer/page.tsx
@@ -17,6 +17,12 @@ export default async function OsomExplorer(props: PageProps) {
         dataset have been excerpted here for you to explore. Use this map and the controls below to
         see how the temperature, water salinity, and kinetic energy change over space and time.
       </p>
+      <p style={{ marginTop: '1rem' }}>
+        NetCDF files for the entire OSOM dataset are available for download from{' '}
+        <ExternalLink href="https://app.globus.org/file-manager?origin_id=660ecb5a-b446-4a71-9518-a98da0c12252&origin_path=%2F">
+        a Globus Collection.
+        </ExternalLink>
+      </p>
       <OsomExporerMap dataset={dataset} variable={variable} rasterIndex={rasterIndex} />
       <p>
         To explore more,{' '}

--- a/src/app/datasets/osom/page.tsx
+++ b/src/app/datasets/osom/page.tsx
@@ -150,7 +150,7 @@ const DESCRIPTION = (
       available by the year at 1.5 hour increments. As the model covers the entire Narragansett Bay,
       data is always available at all buoy locations.
     </p>
-    <p className="mt-4 mb-0 !indent-0 !text-left">
+    <p className="mt-4 mb-1 !indent-0 !text-left">
       Looking for the source data? You can download the{' '}
       <ExternalLink href="https://app.globus.org/file-manager?origin_id=fa54d7a3-ea6e-4c80-9486-8d3c2c99d838&origin_path=%2F">
         ROMS forcing files

--- a/src/app/datasets/osom/page.tsx
+++ b/src/app/datasets/osom/page.tsx
@@ -150,14 +150,14 @@ const DESCRIPTION = (
       available by the year at 1.5 hour increments. As the model covers the entire Narragansett Bay,
       data is always available at all buoy locations.
     </p>
-    <p style={{ marginTop: '1rem' }}>
+    <p style={{ marginTop: '1rem', marginBottom: 0, textIndent: 0 }}>
       Looking for the source data? You can download the{' '}
       <ExternalLink href="https://app.globus.org/file-manager?origin_id=fa54d7a3-ea6e-4c80-9486-8d3c2c99d838&origin_path=%2F">
-      ROMS forcing files
+        ROMS forcing files
       </ExternalLink>{' '}
       used to build the model or the{' '}
       <ExternalLink href="https://app.globus.org/file-manager?origin_id=660ecb5a-b446-4a71-9518-a98da0c12252&origin_path=%2F">
-      OSOM annual files
+        OSOM annual files
       </ExternalLink>{' '}
       from Globus Collections.
     </p>

--- a/src/app/datasets/osom/page.tsx
+++ b/src/app/datasets/osom/page.tsx
@@ -150,6 +150,9 @@ const DESCRIPTION = (
       available by the year at 1.5 hour increments. As the model covers the entire Narragansett Bay,
       data is always available at all buoy locations.
     </p>
+
+    <br />
+    
     <p style={{ marginTop: '1rem' }}>
       Looking for the source data? You can download the{' '}
       <ExternalLink href="https://app.globus.org/file-manager?origin_id=fa54d7a3-ea6e-4c80-9486-8d3c2c99d838&origin_path=%2F">

--- a/src/app/datasets/osom/page.tsx
+++ b/src/app/datasets/osom/page.tsx
@@ -150,7 +150,7 @@ const DESCRIPTION = (
       available by the year at 1.5 hour increments. As the model covers the entire Narragansett Bay,
       data is always available at all buoy locations.
     </p>
-    <p className="mt-4 mb-0 indent-0">
+    <p className="mt-4 mb-0 !indent-0 !text-left">
       Looking for the source data? You can download the{' '}
       <ExternalLink href="https://app.globus.org/file-manager?origin_id=fa54d7a3-ea6e-4c80-9486-8d3c2c99d838&origin_path=%2F">
         ROMS forcing files

--- a/src/app/datasets/osom/page.tsx
+++ b/src/app/datasets/osom/page.tsx
@@ -149,9 +149,8 @@ const DESCRIPTION = (
       larger rivers, and the Block Island Shelf circulation from Long Island to Nantucket. Data is
       available by the year at 1.5 hour increments. As the model covers the entire Narragansett Bay,
       data is always available at all buoy locations.
-
-    <br />
-
+    </p>
+    <p className="mt-4 mb-0 indent-0">
       Looking for the source data? You can download the{' '}
       <ExternalLink href="https://app.globus.org/file-manager?origin_id=fa54d7a3-ea6e-4c80-9486-8d3c2c99d838&origin_path=%2F">
         ROMS forcing files

--- a/src/app/datasets/osom/page.tsx
+++ b/src/app/datasets/osom/page.tsx
@@ -150,10 +150,10 @@ const DESCRIPTION = (
       available by the year at 1.5 hour increments. As the model covers the entire Narragansett Bay,
       data is always available at all buoy locations.
     </p>
-    <p>
+    <p style={{ marginTop: '1rem' }}>
       Looking for the source data? You can download the{' '}
       <ExternalLink href="https://app.globus.org/file-manager?origin_id=fa54d7a3-ea6e-4c80-9486-8d3c2c99d838&origin_path=%2F">
-        ROMS forcing files 
+        ROMS forcing files
       </ExternalLink>{' '}
       used to build the model or the{' '}
       <ExternalLink href="https://app.globus.org/file-manager?origin_id=6579142b-9d21-4ab1-b541-e0c471e1e098&origin_path=%2F">

--- a/src/app/datasets/osom/page.tsx
+++ b/src/app/datasets/osom/page.tsx
@@ -149,11 +149,9 @@ const DESCRIPTION = (
       larger rivers, and the Block Island Shelf circulation from Long Island to Nantucket. Data is
       available by the year at 1.5 hour increments. As the model covers the entire Narragansett Bay,
       data is always available at all buoy locations.
-    </p>
 
     <br />
-    
-    <p style={{ marginTop: '1rem' }}>
+
       Looking for the source data? You can download the{' '}
       <ExternalLink href="https://app.globus.org/file-manager?origin_id=fa54d7a3-ea6e-4c80-9486-8d3c2c99d838&origin_path=%2F">
         ROMS forcing files

--- a/src/app/datasets/osom/page.tsx
+++ b/src/app/datasets/osom/page.tsx
@@ -148,5 +148,9 @@ const DESCRIPTION = (
     and the Block Island Shelf circulation from Long Island to Nantucket. Data is available by the
     year at 1.5 hour increments. As the model covers the entire Narragansett Bay, data is always
     available at all buoy locations.
+
+    Looking for the source data? You can download the <ExternalLink href="https://app.globus.org/file-manager?origin_id=fa54d7a3-ea6e-4c80-9486-8d3c2c99d838&origin_path=%2F">ROMS forcing files</ExternalLink> 
+    used to build the model or the <ExternalLink href="https://app.globus.org/file-manager?origin_id=6579142b-9d21-4ab1-b541-e0c471e1e098&origin_path=%2F">OSOM annual files</ExternalLink> from Globus Collections.
+    You will need a Globus Connect account to access the portal.
   </p>
 );

--- a/src/app/datasets/osom/page.tsx
+++ b/src/app/datasets/osom/page.tsx
@@ -153,11 +153,11 @@ const DESCRIPTION = (
     <p style={{ marginTop: '1rem' }}>
       Looking for the source data? You can download the{' '}
       <ExternalLink href="https://app.globus.org/file-manager?origin_id=fa54d7a3-ea6e-4c80-9486-8d3c2c99d838&origin_path=%2F">
-        ROMS forcing files
+      ROMS forcing files
       </ExternalLink>{' '}
       used to build the model or the{' '}
       <ExternalLink href="https://app.globus.org/file-manager?origin_id=660ecb5a-b446-4a71-9518-a98da0c12252&origin_path=%2F">
-        OSOM annual files
+      OSOM annual files
       </ExternalLink>{' '}
       from Globus Collections.
     </p>

--- a/src/app/datasets/osom/page.tsx
+++ b/src/app/datasets/osom/page.tsx
@@ -141,16 +141,25 @@ const OSOM_BUOY_ERROR_LINKS = [
 ];
 
 const DESCRIPTION = (
-  <p>
-    The Ocean State Ocean Model (OSOM), developed in a collaboration between the University of Rhode
-    Island and Brown University, is an application of the Regional Ocean Modeling System (ROMS). The
-    model spans Rhode Island&apos;s major waterways: Narragansett Bay, Mt. Hope Bay, larger rivers,
-    and the Block Island Shelf circulation from Long Island to Nantucket. Data is available by the
-    year at 1.5 hour increments. As the model covers the entire Narragansett Bay, data is always
-    available at all buoy locations.
-
-    Looking for the source data? You can download the <ExternalLink href="https://app.globus.org/file-manager?origin_id=fa54d7a3-ea6e-4c80-9486-8d3c2c99d838&origin_path=%2F">ROMS forcing files</ExternalLink> 
-    used to build the model or the <ExternalLink href="https://app.globus.org/file-manager?origin_id=6579142b-9d21-4ab1-b541-e0c471e1e098&origin_path=%2F">OSOM annual files</ExternalLink> from Globus Collections.
-    You will need a Globus Connect account to access the portal.
-  </p>
+  <>
+    <p>
+      The Ocean State Ocean Model (OSOM), developed in a collaboration between the University of
+      Rhode Island and Brown University, is an application of the Regional Ocean Modeling System
+      (ROMS). The model spans Rhode Island&apos;s major waterways: Narragansett Bay, Mt. Hope Bay,
+      larger rivers, and the Block Island Shelf circulation from Long Island to Nantucket. Data is
+      available by the year at 1.5 hour increments. As the model covers the entire Narragansett Bay,
+      data is always available at all buoy locations.
+    </p>
+    <p>
+      Looking for the source data? You can download the{' '}
+      <ExternalLink href="https://app.globus.org/file-manager?origin_id=fa54d7a3-ea6e-4c80-9486-8d3c2c99d838&origin_path=%2F">
+        ROMS forcing files 
+      </ExternalLink>{' '}
+      used to build the model or the{' '}
+      <ExternalLink href="https://app.globus.org/file-manager?origin_id=6579142b-9d21-4ab1-b541-e0c471e1e098&origin_path=%2F">
+        OSOM annual files
+      </ExternalLink>{' '}
+      from Globus Collections. You will need a Globus Connect account to access the portal.
+    </p>
+  </>
 );

--- a/src/app/datasets/osom/page.tsx
+++ b/src/app/datasets/osom/page.tsx
@@ -150,7 +150,7 @@ const DESCRIPTION = (
       available by the year at 1.5 hour increments. As the model covers the entire Narragansett Bay,
       data is always available at all buoy locations.
     </p>
-    <p className="mt-4 mb-1 !indent-0 !text-left">
+    <p className="!ml-0 !pl-0mt-4 mb-1 !indent-0 !text-left">
       Looking for the source data? You can download the{' '}
       <ExternalLink href="https://app.globus.org/file-manager?origin_id=fa54d7a3-ea6e-4c80-9486-8d3c2c99d838&origin_path=%2F">
         ROMS forcing files

--- a/src/app/datasets/osom/page.tsx
+++ b/src/app/datasets/osom/page.tsx
@@ -150,7 +150,7 @@ const DESCRIPTION = (
       available by the year at 1.5 hour increments. As the model covers the entire Narragansett Bay,
       data is always available at all buoy locations.
     </p>
-    <p className="!ml-0 !pl-0mt-4 mb-1 !indent-0 !text-left">
+    <p className="!ml-0 !pl-0 mt-4 mb-1 !indent-0 !text-left">
       Looking for the source data? You can download the{' '}
       <ExternalLink href="https://app.globus.org/file-manager?origin_id=fa54d7a3-ea6e-4c80-9486-8d3c2c99d838&origin_path=%2F">
         ROMS forcing files

--- a/src/app/datasets/osom/page.tsx
+++ b/src/app/datasets/osom/page.tsx
@@ -150,7 +150,7 @@ const DESCRIPTION = (
       available by the year at 1.5 hour increments. As the model covers the entire Narragansett Bay,
       data is always available at all buoy locations.
     </p>
-    <p style={{ marginTop: '1rem', marginBottom: 0, textIndent: 0 }}>
+    <p style={{ marginTop: '1rem' }}>
       Looking for the source data? You can download the{' '}
       <ExternalLink href="https://app.globus.org/file-manager?origin_id=fa54d7a3-ea6e-4c80-9486-8d3c2c99d838&origin_path=%2F">
         ROMS forcing files

--- a/src/app/datasets/osom/page.tsx
+++ b/src/app/datasets/osom/page.tsx
@@ -156,10 +156,10 @@ const DESCRIPTION = (
         ROMS forcing files
       </ExternalLink>{' '}
       used to build the model or the{' '}
-      <ExternalLink href="https://app.globus.org/file-manager?origin_id=6579142b-9d21-4ab1-b541-e0c471e1e098&origin_path=%2F">
+      <ExternalLink href="https://app.globus.org/file-manager?origin_id=660ecb5a-b446-4a71-9518-a98da0c12252&origin_path=%2F">
         OSOM annual files
       </ExternalLink>{' '}
-      from Globus Collections. You will need a Globus Connect account to access the portal.
+      from Globus Collections.
     </p>
   </>
 );


### PR DESCRIPTION
.…rcing files

This pull request adds links to the source data for the OSOM dataset directly in the dataset description, making it easier for users to access and download the ROMS forcing files and OSOM annual files from Globus Collections. See this [page](https://riddc-dashboard-pr-145-msrencnbiq-uc.a.run.app/datasets/osom) in the preview for the updated text.

Dataset documentation improvements:

* Updated the `DESCRIPTION` in `src/app/datasets/osom/page.tsx` to include direct download links to the ROMS forcing files and OSOM annual files from Globus, and clarified that a Globus Connect account is required for access